### PR TITLE
Support newer versions of Symfony console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/console": "~2.0.*"
+        "symfony/console": "~2.*"
     },
     "autoload": {
         "psr-0": {"FedEx": "src/"}


### PR DESCRIPTION
Actually, we should support 2.*.
