### PR TITLE
added soap require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-soap": "*"
     },
     "require-dev": {
         "symfony/console": "2.*",


### PR DESCRIPTION
I worked in docker container and got exception `Cant find SoapClient`. After research, I found that I don't have php extension for soap.