### PR TITLE
Rename test class to match file name

### DIFF
--- a/tests/FedEx/Tests/ValidationAvailabilityAndCommitmentServiceTest.php
+++ b/tests/FedEx/Tests/ValidationAvailabilityAndCommitmentServiceTest.php
@@ -7,7 +7,7 @@ use FedEx\ValidationAvailabilityAndCommitmentService\ComplexType\ServiceAvailabi
 use FedEx\ValidationAvailabilityAndCommitmentService\ComplexType\ServiceAvailabilityRequest;
 use FedEx\ValidationAvailabilityAndCommitmentService\Request;
 
-class ValidationAvailabilityAndCommitmentService extends TestCase
+class ValidationAvailabilityAndCommitmentServiceTest extends TestCase
 {
     public function testServiceAvailabilityRequest()
     {


### PR DESCRIPTION
Class name didn't match file name, leading to a Composer warning.