### PR TITLE
Error on missing response value. null pointer exception

### DIFF
--- a/src/FedEx/AbstractComplexType.php
+++ b/src/FedEx/AbstractComplexType.php
@@ -73,7 +73,18 @@ abstract class AbstractComplexType
         $setterMethodName = "set{$name}";
         $reflectionClass = new ReflectionClass($this);
         if ($reflectionClass->hasMethod($setterMethodName)) {
-            $reflectionNamedType = $reflectionClass->getMethod($setterMethodName)->getParameters()[0]->getType();
+            $setterFirstParameter = $reflectionClass->getMethod($setterMethodName)->getParameters()[0] ?? null;
+
+            if ($setterFirstParameter === null) {
+                return $nullValue;
+            }
+            
+            $reflectionNamedType = $setterFirstParameter->getType();
+
+            if ($reflectionNamedType === null) {
+                return $nullValue;
+            }
+
             /* @var $reflectionNamedType ReflectionNamedType */
             $parameterClassName = $reflectionNamedType->getName();
 


### PR DESCRIPTION
If the class does not contain the given property and the data type is not defined for the respective setter, the error `Call to a member function getName () on null` is thrown. For example
`$rateReplyDetail->DeliveryTimestamp`