### PR TITLE
AppliedOptions

### DIFF
--- a/src/FedEx/RateService/ComplexType/RateReplyDetail.php
+++ b/src/FedEx/RateService/ComplexType/RateReplyDetail.php
@@ -81,7 +81,7 @@ class RateReplyDetail extends AbstractComplexType
      * @param \FedEx\RateService\SimpleType\ServiceOptionType[]|string[] $appliedOptions
      * @return $this
      */
-    public function setAppliedOptions(array $appliedOptions)
+    public function setAppliedOptions($appliedOptions)
     {
         $this->values['AppliedOptions'] = $appliedOptions;
         return $this;


### PR DESCRIPTION
Removed strong typing from AppliedOptions. With strong typing value is not populated from API response.